### PR TITLE
add custom interval for process.wait

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -203,8 +203,9 @@ Process.prototype.refresh = function(parameters, callback) {
  * @returns {Process}
  */
 
-Process.prototype.wait = function(callback) {
+Process.prototype.wait = function(callback, interval) {
     var self = this;
+    var interval= interval || 1000;
 
     if(self.data.step == 'finished' || self.data.step == 'error') {
         callback(null, self);
@@ -232,7 +233,7 @@ Process.prototype.wait = function(callback) {
                     }
                 }
             });
-        }, 1000);
+        }, interval);
     }
 
     return self;


### PR DESCRIPTION
I have some issues with this function.
Sometime the cloudconvert lib download the files twices.
Increase the interval of the process.wait function solve the issues.