### PR TITLE
Allow piping of process before it has finished

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -205,7 +205,7 @@ Process.prototype.refresh = function(parameters, callback) {
 
 Process.prototype.wait = function(callback, interval) {
     var self = this;
-    var interval= interval || 1000;
+    interval= interval || 1000;
 
     if(self.data.step == 'finished' || self.data.step == 'error') {
         callback(null, self);
@@ -326,7 +326,7 @@ Process.prototype.pipe = function(destination, options) {
     var self = this;
     if(!self.data.output || !self.data.output.url) {
       self.once('finished', function() { self.download(destination, null, null, options); });
-      self.once('error', function(error) { destination.emit('error', error) });
+      self.once('error', function(error) { destination.emit('error', error); });
     } else {
       self.download(destination, null, null, options);
     }

--- a/lib/process.js
+++ b/lib/process.js
@@ -323,7 +323,13 @@ Process.prototype.download = function(destination, remotefile, callback, pipeopt
  * @returns {WriteableStream}
  */
 Process.prototype.pipe = function(destination, options) {
-    this.download(destination, null, null, options);
+    var self = this;
+    if(!self.data.output || !self.data.output.url) {
+      self.once('finished', function() { self.download(destination, null, null, options); });
+      self.once('error', function(error) { destination.emit('error', error) });
+    } else {
+      self.download(destination, null, null, options);
+    }
     return destination;
 };
 


### PR DESCRIPTION
This PR allows you to do the following:

```javascript
fs.createReadStream('tests/input.png').pipe(cloudconvert.convert({
  inputformat: 'png',
  outputformat: 'jpg'
})).pipe(fs.createWriteStream('out.jpg');
```

Instead of:
```javascript
fs.createReadStream('tests/input.png').pipe(cloudconvert.convert({
    inputformat: 'png',
    outputformat: 'jpg'
}).on('finished', function(data) {
    this.pipe(fs.createWriteStream('out.jpg'));
}));
```
