### PR TITLE
filename parameter added for upload with proces start

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -94,7 +94,7 @@ Process.prototype.start = function(parameters, callback) {
 
 
     if(parameters.input == 'upload' && parameters.file) {
-        self.upload(parameters.file);
+        self.upload(parameters.file, parameters.filename);
         delete parameters.file;
 
     }


### PR DESCRIPTION
I upload a read-stream for a file with a filename WITHOUT an extension (just a hash), like `6360e4f464b54a526647cc0962b4abad`.

When I upload this, I get an API error although the file is valid.
The api wants a valid filetype for the filename.

If I manually set the filename of the readstream to undefined, the upload succeeds.
This works because the filename is then generated for me by this code:
https://github.com/cloudconvert/cloudconvert-node/blob/master/lib/process.js#L194-L202

I want to be able to set a filename for a readstream, created with https://github.com/cloudconvert/cloudconvert-node/blob/master/lib/process.js#L81-L118