### PR TITLE
add waitForJobToFinish method to JobeResrouce

### DIFF
--- a/lib/JobsResouce.js
+++ b/lib/JobsResouce.js
@@ -1,4 +1,7 @@
 import FormData from 'form-data';
+async function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 export default class JobsResource {
 
@@ -35,6 +38,16 @@ export default class JobsResource {
 
     async subscribeTaskEvent(id, event, callback) {
         this.cloudConvert.subscribe('private-job.' + id + '.tasks', 'task.' + event, callback);
+    }
+    
+    async waitForJobToFinish(jobId, pollingIntervalMS = 2000){
+        let jobData = await this.get(jobId)
+        while (!(jobData.status === 'finished' || jobData.status === 'error')) {
+            jobData = await cloudconvert.jobs.get(jobData.id);
+            await sleep(pollingIntervalMS);
+        }
+
+        return jobData
     }
 
 }


### PR DESCRIPTION
 poll for finished/error status
Make it easier to wait for job to finish, instead of subscribing to events