### PR TITLE
allow custom file name for uploads

### DIFF
--- a/lib/TasksResouce.js
+++ b/lib/TasksResouce.js
@@ -34,7 +34,7 @@ export default class TasksResource {
         await this.cloudConvert.axios.delete('tasks/' + id);
     }
 
-    async upload(task, stream) {
+    async upload(task, stream, filename) {
 
         if (task.operation !== 'import/upload') {
             throw new Error('The task operation is not import/upload');
@@ -50,7 +50,11 @@ export default class TasksResource {
             formData.append(parameter, task.result.form.parameters[parameter]);
         }
 
-        formData.append("file", stream);
+        let fileOptions = {};
+        if (typeof filename == 'string') {
+            fileOptions = { filename: filename };
+        }
+        formData.append("file", stream, fileOptions);
 
         return await this.cloudConvert.axios.post(task.result.form.url, formData, {
             headers: {


### PR DESCRIPTION
V1 had a custom fileName fix: https://github.com/cloudconvert/cloudconvert-node/pull/28 .

Now when I switch to the v2 api, I run into the same limitation of this sdk.
An extra argument allows for custom named uploads with the `form-data` library.
See https://github.com/form-data/form-data/blob/master/lib/form_data.js#L46-L53 for more information.