### PR TITLE
Do not distribute source files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "typescript": "^3.9.6"
   },
   "files": [
-    "lib/",
     "built/"
   ],
   "scripts": {


### PR DESCRIPTION
It is not necessary to distribute the source files. All files necessary to use the library are included in the `built` directory. All typescript annotations come along with it, the source maps are also there.

This tiny change therefore saves some bandwidth and disk space, but it doesn't really change anything about the library.