### PR TITLE
Fix type of task upload, allow using tasks from within jobs

### DIFF
--- a/lib/JobsResource.ts
+++ b/lib/JobsResource.ts
@@ -16,7 +16,7 @@ export interface Job {
     tasks: JobTask[];
 }
 type NotPresentWhenInsideJob = 'job_id' | 'status'
-interface JobTask extends Omit<Task, NotPresentWhenInsideJob> {
+export interface JobTask extends Omit<Task, NotPresentWhenInsideJob> {
     name: string;
     status: JobTaskStatus;
 }

--- a/lib/TasksResource.ts
+++ b/lib/TasksResource.ts
@@ -1,5 +1,6 @@
 import FormData, { Stream } from 'form-data';
 import CloudConvert from './CloudConvert';
+import { JobTask } from './JobsResource';
 
 export type TaskEvent = 'created' | 'updated' | 'finished' | 'failed';
 export type TaskStatus = 'waiting' | 'processing' | 'finished' | 'error';
@@ -359,7 +360,7 @@ export default class TasksResource {
         await this.cloudConvert.axios.delete('tasks/' + id);
     }
 
-    async upload(task: Task, stream: Stream): Promise<any> {
+    async upload(task: Task | JobTask, stream: Stream): Promise<any> {
 
         if (task.operation !== 'import/upload') {
             throw new Error('The task operation is not import/upload');


### PR DESCRIPTION
When comparing the results of getting a task vs. getting a job, one can see that the fields for the tasks differ. In particular, tasks inside jobs do not have an entry for the job id but therefore they add a property `name`. Furthermore, according to the docs, they can be of status queued while this is impossible for tasks that were read directly.

However odd this may be, the types of this library reflect it.

When uploading a file to an import task, it should be allowed to pass both standalone tasks and those contained in jobs. This PR enables this by extending the type from `Task` to `Task | JobTask`.