### PR TITLE
docs(README): add Sandbox section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ const isValid = cloudConvert.webhooks.verify(
 ); // returns true or false
 ```
 
+## Using Sandbox
+
+You can use the Sandbox to avoid consuming your quota while testing your application. The node SDK allows you to do that.
+
+```js
+// Pass `true` to the constructor
+const cloudConvert = new CloudConvert('api_key', true);
+```
+
+> Don't forget to generate MD5 Hashes for the files you will use for testing.
+
 ## Contributing
 
 This section is intended for people who want to contribute to the development of this library.


### PR DESCRIPTION
Good job, guys! :star2: 

Recently I had to use it with Sandbox enabled, but couldn't find anything about enabling Sandbox in this client. The first place I went to was the README, and since I couldn't find it, I had to check the source code.