### PR TITLE
Add dir field to FileResult interface

### DIFF
--- a/lib/TasksResource.ts
+++ b/lib/TasksResource.ts
@@ -361,6 +361,7 @@ export interface Task {
     result?: { files?: FileResult[]; [key: string]: any };
 }
 export interface FileResult {
+    dir?: string;
     filename: string;
     url?: string;
 }


### PR DESCRIPTION
The `dir` field seems to be one of the properties returned from the API in some cases.