### PR TITLE
Set `noUncheckedIndexedAccess` and update deps

### DIFF
--- a/lib/CloudConvert.ts
+++ b/lib/CloudConvert.ts
@@ -77,14 +77,14 @@ export default class CloudConvert {
             this.subscribedChannels?.set(channel, true);
         }
 
-        this.socket.on(event, function (
-            eventChannel: string,
-            eventData: any
-        ): void {
-            if (channel !== eventChannel) {
-                return;
+        this.socket.on(
+            event,
+            function (eventChannel: string, eventData: any): void {
+                if (channel !== eventChannel) {
+                    return;
+                }
+                callback(eventData);
             }
-            callback(eventData);
-        });
+        );
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,25 +16,25 @@
         "url": "https://github.com/cloudconvert/cloudconvert-node/issues"
     },
     "dependencies": {
-        "axios": "^0.20.0",
+        "axios": "^0.21.1",
         "esm": "^3.2.25",
         "form-data": "^3.0.0",
         "socket.io-client": "^2.3.1"
     },
     "devDependencies": {
-        "@types/node": "^14.11.2",
+        "@types/node": "^14.14.19",
         "@types/socket.io-client": "^1.4.34",
-        "@typescript-eslint/eslint-plugin": "^4.3.0",
-        "@typescript-eslint/parser": "^4.3.0",
+        "@typescript-eslint/eslint-plugin": "^4.11.1",
+        "@typescript-eslint/parser": "^4.11.1",
         "chai": "^4.2.0",
-        "eslint": "^7.10.0",
-        "eslint-config-prettier": "^6.12.0",
+        "eslint": "^7.17.0",
+        "eslint-config-prettier": "^7.1.0",
         "eslint-config-typescript": "^3.0.0",
-        "eslint-plugin-prettier": "^3.1.4",
-        "mocha": "^8.1.3",
-        "nock": "^13.0.4",
-        "prettier": "^2.1.2",
-        "typescript": "^4.0.3"
+        "eslint-plugin-prettier": "^3.3.0",
+        "mocha": "^8.2.1",
+        "nock": "^13.0.5",
+        "prettier": "^2.2.1",
+        "typescript": "^4.1.3"
     },
     "files": [
         "built/"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "declaration": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
+        "noUncheckedIndexedAccess": true,
         "keyofStringsOnly": true,
         "module": "commonjs",
         "newLine": "lf",


### PR DESCRIPTION
This PR updates `axios` to version `0.21.1`. In addition, a lot of the development dependencies are updated, including TypeScript.

The compiler configuration can now be updated, constraining unchecked index access. This makes sure that index access on elements of an array (`arr[i]`) is checked against `undefined`. `cloudconvert-node` already does this correctly.

The new linting rules are regarded. This required reformatting the code in one place.

After merging this PR, all of
```shellscript
npm run test
npm run test-integration
npm run lint
```
still succeed.

**Note:** `socket.io-client` has reached version 3. However, updating this dependency requires server-side changes, i.e. the servers needs to be updated to version 3, as well, confer https://socket.io/docs/v3/migrating-from-2-x-to-3-0/