### PR TITLE
Update dependencies and tooling

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
-        'prettier/@typescript-eslint',
+        'prettier',
         'plugin:prettier/recommended'
     ],
     rules: {

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .idea
 node_modules/
+package-lock.json
 built/

--- a/package.json
+++ b/package.json
@@ -18,23 +18,23 @@
     "dependencies": {
         "axios": "^0.21.1",
         "esm": "^3.2.25",
-        "form-data": "^3.0.0",
-        "socket.io-client": "^2.3.1"
+        "form-data": "^4.0.0",
+        "socket.io-client": "^2.4.0"
     },
     "devDependencies": {
-        "@types/node": "^14.14.19",
-        "@types/socket.io-client": "^1.4.34",
-        "@typescript-eslint/eslint-plugin": "^4.11.1",
-        "@typescript-eslint/parser": "^4.11.1",
-        "chai": "^4.2.0",
-        "eslint": "^7.17.0",
-        "eslint-config-prettier": "^7.1.0",
+        "@types/node": "^15.3.1",
+        "@types/socket.io-client": "^1.4.36",
+        "@typescript-eslint/eslint-plugin": "^4.24.0",
+        "@typescript-eslint/parser": "^4.24.0",
+        "chai": "^4.3.4",
+        "eslint": "^7.26.0",
+        "eslint-config-prettier": "^8.3.0",
         "eslint-config-typescript": "^3.0.0",
-        "eslint-plugin-prettier": "^3.3.0",
-        "mocha": "^8.2.1",
-        "nock": "^13.0.5",
-        "prettier": "^2.2.1",
-        "typescript": "^4.1.3"
+        "eslint-plugin-prettier": "^3.4.0",
+        "mocha": "^8.4.0",
+        "nock": "^13.0.11",
+        "prettier": "^2.3.0",
+        "typescript": "^4.2.4"
     },
     "scripts": {
         "prepare": "npm run build",


### PR DESCRIPTION
Updates all deps across major versions unless breaking changes affect this library.

Updates the tooling, mainly linting and tsc version.

Adds `package-lock.json` to `.gitignore`.