### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,25 +16,25 @@
         "url": "https://github.com/cloudconvert/cloudconvert-node/issues"
     },
     "dependencies": {
-        "axios": "^0.26.1",
+        "axios": "^0.27.2",
         "form-data": "^4.0.0",
-        "socket.io-client": "^4.5.1"
+        "socket.io-client": "^4.5.2"
     },
     "devDependencies": {
-        "@types/node": "^17.0.23",
+        "@types/node": "^18.7.16",
         "@types/socket.io-client": "^1.4.36",
-        "@typescript-eslint/eslint-plugin": "^5.19.0",
-        "@typescript-eslint/parser": "^5.19.0",
+        "@typescript-eslint/eslint-plugin": "^5.36.2",
+        "@typescript-eslint/parser": "^5.36.2",
         "chai": "^4.3.6",
-        "eslint": "^7.32.0",
+        "eslint": "^8.23.1",
         "eslint-config-prettier": "^8.5.0",
         "eslint-config-typescript": "^3.0.0",
-        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-prettier": "^4.2.1",
         "esm": "^3.2.25",
         "mocha": "^8.4.0",
-        "nock": "^13.2.4",
-        "prettier": "^2.6.2",
-        "typescript": "^4.6.3"
+        "nock": "^13.2.9",
+        "prettier": "^2.7.1",
+        "typescript": "^4.8.3"
     },
     "scripts": {
         "prepare": "npm run build",


### PR DESCRIPTION
Updates all deps again.

It seems like we are stuck with `mocha@8`, though. Updating to latest (`mocha@10`) is not possible because the ESM setup breaks with that. I have played around a bit with this, but did not make much progress. Most likely, Mocha v9 broke things for us: https://github.com/mochajs/mocha/releases/tag/v9.0.0

@josiasmontag are you aware of any way to update?