### PR TITLE
feat: add `jobs.getExportUrls` utility

### DIFF
--- a/lib/JobsResource.ts
+++ b/lib/JobsResource.ts
@@ -1,5 +1,6 @@
 import CloudConvert from './CloudConvert';
 import {
+    type FileResult,
     type Operation,
     type Task,
     type TaskEventData,
@@ -98,6 +99,10 @@ export default class JobsResource {
             `task.${event}`,
             callback
         );
+    }
+
+    getExportUrls(job: Job): FileResult[] {
+        return job.tasks.flatMap(task => task.result?.files ?? []);
     }
 }
 


### PR DESCRIPTION
This adds a utility method which allows library consumers to turn a job into a list of file results.

Contrary to what was suggested in #91, this does not add a class `Job` which would have to be instantiated in many different places. Therefore, it does not require a hydration of all API call results. Currently, all interactions with jobs and tasks happen through `cloudconvert.jobs` and `cloudconvert.tasks`, so doing this would work, but not be very consistent.

Closes #91.