### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,22 +16,22 @@
         "url": "https://github.com/cloudconvert/cloudconvert-node/issues"
     },
     "dependencies": {
-        "axios": "^1.3.3",
+        "axios": "^0.27.2",
         "form-data": "^4.0.0",
-        "socket.io-client": "^4.6.0"
+        "socket.io-client": "^4.6.1"
     },
     "devDependencies": {
         "@types/node": "^18.14.0",
         "@types/socket.io-client": "^1.4.36",
-        "@typescript-eslint/eslint-plugin": "^5.52.0",
-        "@typescript-eslint/parser": "^5.52.0",
+        "@typescript-eslint/eslint-plugin": "^5.53.0",
+        "@typescript-eslint/parser": "^5.53.0",
         "chai": "^4.3.7",
         "eslint": "^8.34.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-config-typescript": "^3.0.0",
         "eslint-plugin-prettier": "^4.2.1",
         "esm": "^3.2.25",
-        "mocha": "^10.2.0",
+        "mocha": "^8.4.0",
         "nock": "^13.3.0",
         "prettier": "^2.8.4",
         "typescript": "^4.9.5"

--- a/package.json
+++ b/package.json
@@ -16,25 +16,25 @@
         "url": "https://github.com/cloudconvert/cloudconvert-node/issues"
     },
     "dependencies": {
-        "axios": "^0.27.2",
+        "axios": "^1.3.3",
         "form-data": "^4.0.0",
-        "socket.io-client": "^4.5.2"
+        "socket.io-client": "^4.6.0"
     },
     "devDependencies": {
-        "@types/node": "^18.7.16",
+        "@types/node": "^18.14.0",
         "@types/socket.io-client": "^1.4.36",
-        "@typescript-eslint/eslint-plugin": "^5.36.2",
-        "@typescript-eslint/parser": "^5.36.2",
-        "chai": "^4.3.6",
-        "eslint": "^8.23.1",
-        "eslint-config-prettier": "^8.5.0",
+        "@typescript-eslint/eslint-plugin": "^5.52.0",
+        "@typescript-eslint/parser": "^5.52.0",
+        "chai": "^4.3.7",
+        "eslint": "^8.34.0",
+        "eslint-config-prettier": "^8.6.0",
         "eslint-config-typescript": "^3.0.0",
         "eslint-plugin-prettier": "^4.2.1",
         "esm": "^3.2.25",
-        "mocha": "^8.4.0",
-        "nock": "^13.2.9",
-        "prettier": "^2.7.1",
-        "typescript": "^4.8.3"
+        "mocha": "^10.2.0",
+        "nock": "^13.3.0",
+        "prettier": "^2.8.4",
+        "typescript": "^4.9.5"
     },
     "scripts": {
         "prepare": "npm run build",


### PR DESCRIPTION
The dependencies are a little outdated. This pull request brings them to the latest version.

Neither axios nor mocha are updated across major version as this would make the tests fail.