### PR TITLE
Implement Websocket reconnect logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ When you don't want to receive any events any more you should close the socket:
 ```js
 cloudConvert.closeSocket();
 ```
+> **Note on websocket connection**:
+The Websocket connection has a [connection state recovery](https://socket.io/docs/v4/connection-state-recovery) configured. The adapter will try to reconnect in 2 minutes (at a maximum of 15 minutes) every time a connection is lost.
+You can also implement an error handler logic by doing `cloudConvert.socket.on('connect_error', ...)` (see how to [troubleshoot connection issues](https://socket.io/docs/v4/troubleshooting-connection-issues/)).
+
 
 ## Webhook Signing
 

--- a/lib/CloudConvert.ts
+++ b/lib/CloudConvert.ts
@@ -11,13 +11,13 @@ import { version } from '../package.json';
 import SignedUrlResource from './SignedUrlResource';
 
 export default class CloudConvert {
-    private socket: SocketIOClient.Socket | undefined;
     private subscribedChannels: Map<string, boolean> | undefined;
 
     public readonly apiKey: string;
     public readonly useSandbox: boolean;
     public readonly region: string | null;
 
+    public socket: SocketIOClient.Socket | undefined;
     public axios!: AxiosInstance;
     public tasks!: TasksResource;
     public jobs!: JobsResource;
@@ -70,7 +70,10 @@ export default class CloudConvert {
                     ? 'https://socketio.sandbox.cloudconvert.com'
                     : 'https://socketio.cloudconvert.com',
                 {
-                    transports: ['websocket']
+                    transports: ['websocket'],
+                    reconnection: true,
+                    reconnectionDelay: 2 * 60 * 1000, // two minutes
+                    reconnectionDelayMax: 15 * 60 * 1000 // 15 minutes
                 }
             );
             this.subscribedChannels = new Map<string, boolean>();


### PR DESCRIPTION
Introduce [Connection State Recovery](https://socket.io/docs/v4/connection-state-recovery) logic to the WebSocket implementation and make the socket property public to allow extending error handling and other socket-based functionalities.

## Changes:
#### 1. Reconnection Logic:
Added reconnection options to the Socket.io initialization to handle automatic reconnections.

#### 2. Public Socket Property:
Set `this.socket` to be a public property, enabling developers to access and extend the socket instance for custom implementations such as error handling, event logging, etc.
